### PR TITLE
fix: 修改输入文本在包含等号时不需要转换

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ class MyCompletionItemProvider implements vscode.CompletionItemProvider {
     const linePrefix = document
       .lineAt(position).text.slice(0, position.character)?.trimStart() || '';
 
-    if (!linePrefix.startsWith("const ") || !linePrefix.split("const ")[1]) {
+    if (!linePrefix.startsWith("const ") || !linePrefix.split("const ")[1] || linePrefix.indexOf("=") > -1) {
       this.str = "";
       return [];
     }


### PR DESCRIPTION
- 判断输入文本包含等号时就不再进行转换


在进行函数声明时，得多按一次键来取消提示，不然花括号内回车换行就会进行转换，而这种情况，无论是箭头函数还是普通函数，只要是使用 const 进行等式的声明，基本判定是不需要再进行转换了的
![1669255946802](https://user-images.githubusercontent.com/20277731/203679479-000c763d-dab9-47ac-a01d-e08851c3c465.jpg)
